### PR TITLE
Allow `window` to be the viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ angular-in-viewport
 Set of directives handling events when a DOM element enters or leaves a viewport
 
 ### viewport
-Directive (attribute) specifying the DOM element which should be used as viewport
+Directive (attribute) specifying the DOM element which should be used as viewport.
+
+To use `window` as the viewport element, set `viewport="window"` on any parent element.
 
 ### viewport-enter
 Directive (attribute) specifying a DOM element which should be watched. When the element enters the viewport the value of the attribute will be evaled.
@@ -19,11 +21,22 @@ Directive (attribute) specifying a DOM element which should be watched. When the
 Directive (attribute) specifying a DOM element which should be watched. When the element leaves the viewport the value of the attribute will be evaled.
 
 #Compatibility
-This plugin has been tested with Angular 1.2 and 1.3
+This plugin works with Angular 1.x (v1.2 and higher)
 
 #Example
+
+Viewport container element:
+
 ```HTML
 <ul style="width: 200px; height: 200px" viewport>
+  <li ng-repeat="item in items" style="width: 200px; height: 200px" viewport-leave="item.visible = false" viewport-enter="item.visible = true">
+</ul>
+```
+
+Window viewport:
+
+```HTML
+<ul style="width: 200px; height: 200px" viewport="window">
   <li ng-repeat="item in items" style="width: 200px; height: 200px" viewport-leave="item.visible = false" viewport-enter="item.visible = true">
 </ul>
 ```

--- a/examples/app.css
+++ b/examples/app.css
@@ -1,9 +1,12 @@
 html, body {
     width: 100%;
     height: 100%;
-    background: #e9e9e9;
-    overflow: hidden;
     margin: 0;
+    padding: 0;
+}
+
+ul {
+    list-style-type: none;
     padding: 0;
 }
 
@@ -12,7 +15,6 @@ html, body {
     height: 100%;
 
     margin: 0 auto;
-    padding: 0;
 
     background: #ffffff;
     border: 1px solid #999;

--- a/examples/window-viewport.html
+++ b/examples/window-viewport.html
@@ -8,9 +8,9 @@
         <link href="app.css" rel="stylesheet" />
     </head>
 
-    <body ng-controller="TestCtrl" style="background: #e9e9e9; overflow: hidden;">
+    <body ng-controller="TestCtrl" viewport="window">
 
-        <ul class="viewport" viewport>
+        <ul>
             <li class="item"
                 ng-repeat="item in items track by $index"
                 viewport-enter="item.inViewport = true"

--- a/src/directives/viewport.directive.js
+++ b/src/directives/viewport.directive.js
@@ -8,15 +8,17 @@
     /**
      * Directive Definition for Viewport
      */
-    function ViewportDefinition()
+    function ViewportDefinition($window)
     {
         return {
             restrict: 'A',
             scope: true,
             controller: ViewportController,
-            link: ViewportLinking
+            link: viewportLinking($window)
         };
     }
+
+    ViewportDefinition.$inject = ['$window'];
 
     /**
      * Controller for viewport directive
@@ -24,7 +26,7 @@
      */
     function ViewportController($window)
     {
-        var viewport    = null,
+        var viewportFn  = null,
             isUpdating  = false,
             updateAgain = false,
             elements    = [], // keep elements in array for quick lookup
@@ -37,7 +39,7 @@
                 elementRect,
                 inViewport;
 
-            if (!viewport) {
+            if (!viewportFn) {
                 return;
             }
 
@@ -48,16 +50,16 @@
 
             isUpdating = true;
 
-            viewportRect = viewport.getBoundingClientRect();
+            viewportRect = viewportFn();
 
             angular.forEach(items, function (item) {
                 elementRect = item.element.getBoundingClientRect();
 
                 inViewport =
                     pointIsInsideBounds(elementRect.left, elementRect.top, viewportRect) ||
-                    pointIsInsideBounds(elementRect.left + elementRect.width, elementRect.top, viewportRect) ||
-                    pointIsInsideBounds(elementRect.left, elementRect.top + elementRect.height, viewportRect) ||
-                    pointIsInsideBounds(elementRect.left + elementRect.width, elementRect.top + elementRect.height, viewportRect);
+                    pointIsInsideBounds(elementRect.right, elementRect.top, viewportRect) ||
+                    pointIsInsideBounds(elementRect.left, elementRect.bottom, viewportRect) ||
+                    pointIsInsideBounds(elementRect.right, elementRect.bottom, viewportRect);
 
                 // On first check and on change
                 if (item.state === null || item.state !== inViewport) {
@@ -88,28 +90,25 @@
          */
         function pointIsInsideBounds(x, y, bounds)
         {
-            return  x >= bounds.left &&
-            y >= bounds.top &&
-            x <= bounds.left + bounds.width &&
-            y <= bounds.top + bounds.height;
+            return x >= bounds.left && x <= bounds.right && y >= bounds.top && y <= bounds.bottom;
         }
 
         /**
-         * Set the viewport element
-         * @param element
+         * Set the viewport box function
+         * @param function
          */
-        function setViewport(element)
+        function setViewportFn(fn)
         {
-            viewport = element;
+            viewportFn = fn;
         }
 
         /**
-         * Return the current viewport
+         * Return the current viewport box function
          * @returns {*}
          */
-        function getViewport()
+        function getViewportFn()
         {
-            return viewport;
+            return viewportFn;
         }
 
         /**
@@ -167,8 +166,8 @@
             .on('resize', updateDelayed)
             .on('orientationchange', updateDelayed);
 
-        this.setViewport    = setViewport;
-        this.getViewport    = getViewport;
+        this.setViewportFn  = setViewportFn;
+        this.getViewportFn  = getViewportFn;
         this.add            = add;
         this.getItems       = getItems;
         this.updateDelayed  = updateDelayed;
@@ -186,17 +185,37 @@
      * @param $timeout
      * @constructor
      */
-    function ViewportLinking($scope, iElement, iAttrs, viewport)
+    function viewportLinking($window)
     {
-        viewport.setViewport(iElement[0]);
-        iElement.on('scroll', viewport.updateDelayed);
+        var linkFn = function($scope, iElement, iAttrs, $ctrl) {
+            if (iAttrs.viewport === 'window') {
+                $ctrl.setViewportFn(function() {
+                    return {
+                        top: 0,
+                        left: 0,
+                        bottom: window.innerHeight || document.documentElement.clientHeight,
+                        right: window.innerWidth || document.documentElement.clientWidth
+                    };
+                });
+                angular.element($window).on('scroll', $ctrl.updateDelayed);
+            } else {
+                $ctrl.setViewportFn(function() {
+                    return iElement[0].getBoundingClientRect();
+                });
+                iElement.on('scroll', $ctrl.updateDelayed);
+            }
 
-        // Trick angular in calling this on digest
-        $scope.$watch(function () {
-            viewport.updateDelayed();
-        });
+            // Trick angular in calling this on digest
+            $scope.$watch(function () {
+                $ctrl.updateDelayed();
+            });
+        };
+
+        linkFn.$inject = ['$scope', 'iElement', 'iAttrs', 'viewport'];
+
+        return linkFn;
     }
 
-    ViewportLinking.$inject = ['$scope', 'iElement', 'iAttrs', 'viewport'];
+    viewportLinking.$inject = ['$window'];
 
 })(window.angular);

--- a/test/spec/directives/enter.directive.spec.js
+++ b/test/spec/directives/enter.directive.spec.js
@@ -25,7 +25,7 @@ describe('in-viewport: viewport-enter directive', function() {
                 });
             };
             this.updateDelayed = function () {};
-            this.setViewport = function () {};
+            this.setViewportFn = function () {};
 
             viewportMockController = this;
             spyOn(viewportMockController, 'add').and.callThrough();

--- a/test/spec/directives/leave.directive.spec.js
+++ b/test/spec/directives/leave.directive.spec.js
@@ -25,7 +25,7 @@ describe('in-viewport: viewport-leave directive', function() {
                 });
             };
             this.updateDelayed = function () {};
-            this.setViewport = function () {};
+            this.setViewportFn = function () {};
 
             viewportMockController = this;
             spyOn(viewportMockController, 'add').and.callThrough();

--- a/test/spec/directives/viewport.directive.spec.js
+++ b/test/spec/directives/viewport.directive.spec.js
@@ -35,11 +35,11 @@ describe('in-viewport: viewport directive', function() {
             controller = element.controller('viewport');
         });
 
-        describe('setViewport/getViewport', function () {
-            it('should set/get the current viewport element', function () {
+        describe('setViewportFn/getViewportFn', function () {
+            it('should set/get the current viewport box function', function () {
                 var viewport = {};
-                controller.setViewport(viewport);
-                expect(controller.getViewport()).toEqual(viewport);
+                controller.setViewportFn(viewport);
+                expect(controller.getViewportFn()).toEqual(viewport);
             });
         });
 


### PR DESCRIPTION
To use `window` as the viewport element, set `viewport="window"` on any parent element.

Resolves #4